### PR TITLE
Break Non-Damageable Items

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -24,3 +24,4 @@ Impelon (Ovi T.), #3
 List of contributors
 ====================
 * democat3457 (Colin W.), [#52](https://github.com/Impelon/Disenchanter/pull/52)
+* Charles445, [#60](https://github.com/Impelon/Disenchanter/pull/60)

--- a/src/main/java/de/impelon/disenchanter/DisenchanterConfig.java
+++ b/src/main/java/de/impelon/disenchanter/DisenchanterConfig.java
@@ -156,6 +156,10 @@ public class DisenchanterConfig {
 						 "Enchantments will not be able to be removed from these items."})
 		public boolean enableTCBehaviour = true;
 		
+		@Config.Name("DestroyNonDamageableItems")
+		@Config.Comment("Should non-damageable items like books be destroyed when disenchanted?")
+		public boolean destroyNonDamageableItems = false;
+		
 	};
 	
 	@Config.Name("visual")

--- a/src/main/java/de/impelon/disenchanter/DisenchantingUtils.java
+++ b/src/main/java/de/impelon/disenchanter/DisenchantingUtils.java
@@ -560,7 +560,7 @@ public class DisenchantingUtils {
 
 	/**
 	 * <p>
-	 * Returns whether the given itemstack should break after one use (for non-damageable items)
+	 * Returns whether the given itemstack should break (for non-damageable items).
 	 * </p>
 	 * 
 	 * @param itemstack the itemstack to check

--- a/src/main/java/de/impelon/disenchanter/DisenchantingUtils.java
+++ b/src/main/java/de/impelon/disenchanter/DisenchantingUtils.java
@@ -247,7 +247,7 @@ public class DisenchantingUtils {
 				receiver = ItemStack.EMPTY;
 			inventory.setReceiverStack(receiver);
 
-			if (isItemStackBroken(source))
+			if (isItemStackBroken(source) || shouldNonDamageableBreak(source))
 				source = ItemStack.EMPTY;
 
 			if (!source.isEmpty()) {
@@ -340,7 +340,7 @@ public class DisenchantingUtils {
 			source.attemptDamageItem((int) (dmgMultiplier * (flatDmg + source.getMaxDamage() * durabilityDmg
 					+ source.getMaxDamage() * (reducibleDmg / power))), random, null);
 
-			if (isItemStackBroken(source) || !properties.is(TableVariant.BULKDISENCHANTING))
+			if (isItemStackBroken(source) || shouldNonDamageableBreak(source) || !properties.is(TableVariant.BULKDISENCHANTING))
 				break;
 		}
 		return hasTransferredEnchantments;
@@ -556,6 +556,18 @@ public class DisenchantingUtils {
 	 */
 	public static boolean isItemStackBroken(ItemStack itemstack) {
 		return itemstack.isItemStackDamageable() && itemstack.getItemDamage() > itemstack.getMaxDamage();
+	}
+
+	/**
+	 * <p>
+	 * Returns whether the given itemstack should break after one use (for non-damageable items)
+	 * </p>
+	 * 
+	 * @param itemstack the itemstack to check
+	 * @return true if the itemstack is non-damageable and should be broken, false otherwise
+	 */
+	public static boolean shouldNonDamageableBreak(ItemStack itemstack) {
+		return DisenchanterConfig.disenchanting.destroyNonDamageableItems && !itemstack.isItemStackDamageable();
 	}
 
 	/**


### PR DESCRIPTION
#59 
Config and implementation to allow the breaking of items like books when disenchanted. Disabled by default.

Note that a bulk disenchanter will only remove one enchantment before breaking the item.